### PR TITLE
Use the iterate method instead of the all method to get `table_data`

### DIFF
--- a/tap_airtable/__init__.py
+++ b/tap_airtable/__init__.py
@@ -49,9 +49,8 @@ def get_table_schema(base, table):
         }
     }
 
-  # TODO: throw error if table in config doesn't match table in base
-  # TODO: change this to table.iterate
-    table_data = base.all(table)
+    # TODO: throw error if table in config doesn't match table in base
+    table_data = (record for page in base.iterate(table) for record in page)
 
     for row in table_data:
         for field, value in row["fields"].items():


### PR DESCRIPTION
[`iterate`](https://pyairtable.readthedocs.io/en/latest/api.html?highlight=all#pyairtable.api.Table.iterate) fetches records in pages,
where each page fetched is a list, and `iterate`'s return value is a generator of those list/pages.

`all` concatenates each of those pages of records into a single eagerly-evaluated list.

This commit replaces the use of `all` with a call to `iterate` in a generator comprehension to flatten the generator.